### PR TITLE
Refactor TikZ diagrams for GRU, LSTM, and DilatedCNN (active branches only)

### DIFF
--- a/pytorch/dilated_cnn_tikz.tex
+++ b/pytorch/dilated_cnn_tikz.tex
@@ -1,62 +1,43 @@
-\documentclass[tikz,border=10pt]{standalone}
-\usetikzlibrary{arrows.meta, positioning, shapes.geometric}
+\documentclass[tikz,border=8pt]{standalone}
+\usetikzlibrary{arrows.meta,positioning}
 
 \begin{document}
 \begin{tikzpicture}[
-    block/.style={draw, thick, minimum width=2.6cm, minimum height=1.1cm, align=center, rounded corners=3pt},
-    arrow/.style={-{Latex[length=3mm]}, thick}
+  font=\small,
+  block/.style={draw, rounded corners=2pt, very thick, align=center, minimum width=3.8cm, minimum height=1.2cm, fill=blue!5},
+  tblock/.style={block, fill=orange!12},
+  sblock/.style={block, fill=green!12},
+  hblock/.style={block, fill=purple!12},
+  io/.style={block, fill=red!8},
+  arr/.style={-{Latex[length=2.8mm]}, thick}
 ]
-    % Input sequence information
-    \node[block, fill=blue!10] (input) {Input\\$X \in \mathbb{R}^{B \times C_{in} \times T}$\\
-        $C_{in} = \texttt{in\_channels}$\\
-        $T = \texttt{n\_sequences}$};
 
-    % Dilated convolution stack
-    \node[block, right=2.9cm of input, fill=orange!15] (dilated) {Dilated convolution stack\\
-        channels $= \texttt{ch}$\\
-        dilations $= \texttt{di}$\\
-        norm (BatchNorm1d) + $\texttt{act\_func}$ + dropout $= \texttt{dropout}$};
+\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$};
+\node[tblock, right=2.2cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$};
+\node[tblock, right=2.2cm of split] (cnn1) {Dilated Conv1d ($d=1$)\\$(B,\ g,\ T) \rightarrow (B,\ 128,\ T)$};
+\node[tblock, right=2.2cm of cnn1] (cnn2) {Dilated Conv1d ($d=3$)\\$(B,\ 128,\ T) \rightarrow (B,\ 128,\ T)$};
+\node[tblock, right=2.2cm of cnn2] (pool) {Temporal pooling (attn)\\$(B,\ 128,\ T) \rightarrow (B,\ 128)$};
 
-    \draw[arrow] (input) -- (dilated);
+\node[sblock, below=2.2cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$};
+\node[sblock, right=2.2cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
-    % Last timestep extraction
-    \node[block, right=2.9cm of dilated, fill=orange!10] (last) {Last time step extraction\\
-        $z_T \in \mathbb{R}^{B \times \texttt{ch}_{\mathrm{last}}}$};
+\node[hblock, right=2.2cm of pool] (fusion) {Concatenation (time mode)\\$(B,\128)\oplus(B,\64) \rightarrow (B,\192)$};
+\node[hblock, right=2.2cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\192) \rightarrow (B,\128)$};
+\node[hblock, right=2.2cm of tfuse] (head1) {Head linear 1 + act\\$(B,\128) \rightarrow (B,\256)$};
+\node[hblock, right=2.2cm of head1] (head2) {Head linear 2 + act\\$(B,\256) \rightarrow (B,\64)$};
+\node[io, right=2.2cm of head2] (out) {Output layer\\$(B,\64) \rightarrow (B,\O)$};
 
-    \draw[arrow] (dilated) -- node[above]{temporal output} (last);
-
-    % Linear layers and activations
-    \node[block, below=1.7cm of last, fill=purple!10] (linear1) {Linear layer\\$\mathbb{R}^{\texttt{ch}_{\mathrm{last}}} \rightarrow \mathbb{R}^{\texttt{lc}}$\\
-        activation $\texttt{act\_func}$};
-
-    \draw[arrow] (last) -- (linear1);
-
-    \node[block, below=1.7cm of linear1, fill=purple!8] (linear2) {Linear layer\\$\mathbb{R}^{\texttt{lc}} \rightarrow \mathbb{R}^{\texttt{ec}}$\\
-        activation $\texttt{act\_func}$};
-
-    \draw[arrow] (linear1) -- (linear2);
-
-    \node[block, below=1.7cm of linear2, fill=red!10] (output) {Output layer\\$\mathbb{R}^{\texttt{ec}} \rightarrow \mathbb{R}^{C_{out}}$};
-
-    \draw[arrow] (linear2) -- (output);
-
-    % Legends for parameters
-    \node[below=1.5cm of input, align=left] (legend) {
-        \begin{minipage}{11cm}
-            \textbf{Default parameters:}
-            \begin{itemize}
-                \item $\texttt{in\_channels} = C_{in}$ (input dimension)
-                \item $\texttt{n\_sequences} = 11$
-                \item $\texttt{ch} = [C_{in}, C_{in}, 128]$, $\texttt{di} = [1, 3, 4]$
-                \item $\texttt{lc} = \texttt{lin\_channels} = 256$
-                \item $\texttt{ec} = \texttt{end\_channels} = 64$
-                \item $\texttt{out\_channels} = 5$
-                \item $\texttt{dropout} = 0.03$, $\texttt{act\_func} = \text{ReLU}$
-                \item $\texttt{ch}_{\mathrm{last}} = \texttt{ch}[-1] = 128$
-                \item Output activation depends on $\texttt{task\_type}$
-            \end{itemize}
-        \end{minipage}
-    };
-
+\draw[arr] (xin) -- (split);
+\draw[arr] (split) -- (cnn1);
+\draw[arr] (cnn1) -- (cnn2);
+\draw[arr] (cnn2) -- (pool);
+\draw[arr] (pool) -- (fusion);
+\draw[arr] (xin) |- (ssplit);
+\draw[arr] (ssplit) -- (smlp);
+\draw[arr] (smlp) -| (fusion);
+\draw[arr] (fusion) -- (tfuse);
+\draw[arr] (tfuse) -- (head1);
+\draw[arr] (head1) -- (head2);
+\draw[arr] (head2) -- (out);
 \end{tikzpicture}
 \end{document}

--- a/pytorch/gru_tikz.tex
+++ b/pytorch/gru_tikz.tex
@@ -1,65 +1,45 @@
-\documentclass[tikz,border=10pt]{standalone}
-\usetikzlibrary{arrows.meta, positioning, shapes.geometric}
+\documentclass[tikz,border=8pt]{standalone}
+\usetikzlibrary{arrows.meta,positioning,fit,calc}
 
 \begin{document}
 \begin{tikzpicture}[
-    block/.style={draw, thick, minimum width=2.6cm, minimum height=1.1cm, align=center, rounded corners=3pt},
-    arrow/.style={-{Latex[length=3mm]}, thick}
+  font=\small,
+  block/.style={draw, rounded corners=2pt, very thick, align=center, minimum width=3.8cm, minimum height=1.2cm, fill=blue!5},
+  tblock/.style={block, fill=orange!12},
+  sblock/.style={block, fill=green!12},
+  hblock/.style={block, fill=purple!12},
+  io/.style={block, fill=red!8},
+  arr/.style={-{Latex[length=2.8mm]}, thick}
 ]
-    % Input sequence information
-    \node[block, fill=blue!10] (input) {Input\\$X \in \mathbb{R}^{B \times C_{in} \times T}$\\
-        $C_{in} = \texttt{in\_channels}$\\
-        $T = \texttt{n\_sequences}$};
 
-    % GRU block
-    \node[block, right=2.9cm of input, fill=orange!15] (gru) {Stacked GRU\\
-        $\texttt{num\_layers}$\\
-        hidden size $= \texttt{gr}$\\
-        inter-layer dropout $= \texttt{dropout}$};
+% Temporal branch
+\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$};
+\node[tblock, right=2.2cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$\\$g=|\texttt{temporal\_idx}|$};
+\node[tblock, right=2.2cm of split] (gru) {2-layer GRU\\$(B,\ g,\ T) \rightarrow (B,\ T,\ G)$\\$G=\texttt{gru\_size}=128$};
+\node[tblock, right=2.2cm of gru] (pool) {Temporal pooling (flatten)\\$(B,\ T,\ G) \rightarrow (B,\ T\cdot G)$};
 
-    \draw[arrow] (input) -- (gru);
+% Spatial branch
+\node[sblock, below=2.2cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$\\$s=|\texttt{static\_idx}|$};
+\node[sblock, right=2.2cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
-    % Last timestep extraction
-    \node[block, right=2.9cm of gru, fill=orange!10] (last) {Last time step extraction\\
-        $h_T \in \mathbb{R}^{B \times gr}$};
+% Fusion + head
+\node[hblock, right=2.2cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ T\cdot G)\oplus(B,\64) \rightarrow (B,\ T\cdot G+64)$};
+\node[hblock, right=2.2cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ T\cdot G+64) \rightarrow (B,\ 128)$};
+\node[hblock, right=2.2cm of tfuse] (head1) {Head linear 1 + act\\$(B,\ 128) \rightarrow (B,\ 256)$};
+\node[hblock, right=2.2cm of head1] (head2) {Head linear 2 + act\\$(B,\ 256) \rightarrow (B,\ 64)$};
+\node[io, right=2.2cm of head2] (out) {Output layer\\$(B,\ 64) \rightarrow (B,\ O)$\\$O=\texttt{out\_channels}$};
 
-    \draw[arrow] (gru) -- node[above]{temporal output} (last);
-
-    % Normalization & dropout
-    \node[block, below=1.7cm of last, fill=green!12] (norm) {Normalization (BatchNorm1d by default)\\then dropout $p=\texttt{dropout}$};
-
-    \draw[arrow] (last) -- (norm);
-
-    % Linear layers and activations
-    \node[block, below=1.7cm of norm, fill=purple!10] (linear1) {Linear layer\\$\mathbb{R}^{gr} \rightarrow \mathbb{R}^{hd}$\\
-        activation $\texttt{act\_func}$};
-
-    \draw[arrow] (norm) -- (linear1);
-
-    \node[block, below=1.7cm of linear1, fill=purple!8] (linear2) {Linear layer\\$\mathbb{R}^{hd} \rightarrow \mathbb{R}^{ec}$\\
-        activation $\texttt{act\_func}$};
-
-    \draw[arrow] (linear1) -- (linear2);
-
-    \node[block, below=1.7cm of linear2, fill=red!10] (output) {Output layer\\$\mathbb{R}^{ec} \rightarrow \mathbb{R}^{C_{out}}$};
-
-    \draw[arrow] (linear2) -- (output);
-
-    % Legends for parameters
-    \node[below=1.5cm of input, align=left] (legend) {
-        \begin{minipage}{10cm}
-            \textbf{Default parameters:}
-            \begin{itemize}
-                \item $\texttt{in\_channels} = C_{in}$ (input dimension)
-                \item $\texttt{n\_sequences} = 11$
-                \item $\texttt{gr} = 128$, $\texttt{num\_layers} = 2$
-                \item $\texttt{hd} = 256$, $\texttt{ec} = 64$
-                \item $\texttt{out\_channels} = 5$
-                \item $\texttt{dropout} = 0.03$
-                \item Internal activation ReLU
-            \end{itemize}
-        \end{minipage}
-    };
+\draw[arr] (xin) -- (split);
+\draw[arr] (split) -- (gru);
+\draw[arr] (gru) -- (pool);
+\draw[arr] (pool) -- (fusion);
+\draw[arr] (xin) |- (ssplit);
+\draw[arr] (ssplit) -- (smlp);
+\draw[arr] (smlp) -| (fusion);
+\draw[arr] (fusion) -- (tfuse);
+\draw[arr] (tfuse) -- (head1);
+\draw[arr] (head1) -- (head2);
+\draw[arr] (head2) -- (out);
 
 \end{tikzpicture}
 \end{document}

--- a/pytorch/lstm_tikz.tex
+++ b/pytorch/lstm_tikz.tex
@@ -1,65 +1,41 @@
-\documentclass[tikz,border=10pt]{standalone}
-\usetikzlibrary{arrows.meta, positioning, shapes.geometric}
+\documentclass[tikz,border=8pt]{standalone}
+\usetikzlibrary{arrows.meta,positioning}
 
 \begin{document}
 \begin{tikzpicture}[
-    block/.style={draw, thick, minimum width=2.6cm, minimum height=1.1cm, align=center, rounded corners=3pt},
-    arrow/.style={-{Latex[length=3mm]}, thick}
+  font=\small,
+  block/.style={draw, rounded corners=2pt, very thick, align=center, minimum width=3.8cm, minimum height=1.2cm, fill=blue!5},
+  tblock/.style={block, fill=orange!12},
+  sblock/.style={block, fill=green!12},
+  hblock/.style={block, fill=purple!12},
+  io/.style={block, fill=red!8},
+  arr/.style={-{Latex[length=2.8mm]}, thick}
 ]
-    % Input sequence information
-    \node[block, fill=blue!10] (input) {Input\\$X \in \mathbb{R}^{B \times C_{in} \times T}$\\
-        $C_{in} = \texttt{in\_channels}$\\
-        $T = \texttt{n\_sequences}$};
 
-    % LSTM block
-    \node[block, right=2.9cm of input, fill=orange!15] (lstm) {Stacked LSTM\\
-        $\texttt{num\_layers}$\\
-        hidden size $= \texttt{ls}$\\
-        inter-layer dropout $= \texttt{dropout}$};
+\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$};
+\node[tblock, right=2.2cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$};
+\node[tblock, right=2.2cm of split] (lstm) {2-layer LSTM\\$(B,\ g,\ T) \rightarrow (B,\ T,\ L)$\\$L=\texttt{lstm\_size}=128$};
+\node[tblock, right=2.2cm of lstm] (pool) {Temporal pooling (attn)\\$(B,\ T,\ L) \rightarrow (B,\ L)$};
 
-    \draw[arrow] (input) -- (lstm);
+\node[sblock, below=2.2cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$};
+\node[sblock, right=2.2cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
-    % Last timestep extraction
-    \node[block, right=2.9cm of lstm, fill=orange!10] (last) {Last time step extraction\\
-        $h_T \in \mathbb{R}^{B \times ls}$};
+\node[hblock, right=2.2cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ L)\oplus(B,\64) \rightarrow (B,\ L+64)$};
+\node[hblock, right=2.2cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ L+64) \rightarrow (B,\ 128)$};
+\node[hblock, right=2.2cm of tfuse] (head1) {Head linear 1 + act\\$(B,\ 128) \rightarrow (B,\ 256)$};
+\node[hblock, right=2.2cm of head1] (head2) {Head linear 2 + act\\$(B,\ 256) \rightarrow (B,\ 64)$};
+\node[io, right=2.2cm of head2] (out) {Output layer\\$(B,\ 64) \rightarrow (B,\ O)$};
 
-    \draw[arrow] (lstm) -- node[above]{temporal output} (last);
-
-    % Normalization & dropout
-    \node[block, below=1.7cm of last, fill=green!12] (norm) {Normalization (BatchNorm1d by default)\\then dropout $p=\texttt{dropout}$};
-
-    \draw[arrow] (last) -- (norm);
-
-    % Linear layers and activations
-    \node[block, below=1.7cm of norm, fill=purple!10] (linear1) {Linear layer\\$\mathbb{R}^{ls} \rightarrow \mathbb{R}^{hd}$\\
-        activation $\texttt{act\_func}$};
-
-    \draw[arrow] (norm) -- (linear1);
-
-    \node[block, below=1.7cm of linear1, fill=purple!8] (linear2) {Linear layer\\$\mathbb{R}^{hd} \rightarrow \mathbb{R}^{ec}$\\
-        activation $\texttt{act\_func}$};
-
-    \draw[arrow] (linear1) -- (linear2);
-
-    \node[block, below=1.7cm of linear2, fill=red!10] (output) {Output layer\\$\mathbb{R}^{ec} \rightarrow \mathbb{R}^{C_{out}}$};
-
-    \draw[arrow] (linear2) -- (output);
-
-    % Legends for parameters
-    \node[below=1.5cm of input, align=left] (legend) {
-        \begin{minipage}{10cm}
-            \textbf{Default parameters:}
-            \begin{itemize}
-                \item $\texttt{in\_channels} = C_{in}$ (input dimension)
-                \item $\texttt{n\_sequences} = 11$
-                \item $\texttt{ls} = 128$, $\texttt{num\_layers} = \texttt{num\_lstm\_layers}$ (default 1)
-                \item $\texttt{hd} = 256$, $\texttt{ec} = 64$
-                \item $\texttt{out\_channels} = 5$
-                \item $\texttt{dropout} = 0.03$
-                \item Internal activation ReLU
-            \end{itemize}
-        \end{minipage}
-    };
-
+\draw[arr] (xin) -- (split);
+\draw[arr] (split) -- (lstm);
+\draw[arr] (lstm) -- (pool);
+\draw[arr] (pool) -- (fusion);
+\draw[arr] (xin) |- (ssplit);
+\draw[arr] (ssplit) -- (smlp);
+\draw[arr] (smlp) -| (fusion);
+\draw[arr] (fusion) -- (tfuse);
+\draw[arr] (tfuse) -- (head1);
+\draw[arr] (head1) -- (head2);
+\draw[arr] (head2) -- (out);
 \end{tikzpicture}
 \end{document}


### PR DESCRIPTION
### Motivation
- Provide manuscript-ready TikZ diagrams for the BetterGRU, DilatedCNN and LSTM configurations found in `pytorch/tools_2.py` that show only the active branches used in the models. 
- Make tensor-shape transitions explicit in each block using the requested `(B, I) -> (B, O)` style so diagrams are unambiguous for thesis figures.

### Description
- Updated `pytorch/gru_tikz.tex`, `pytorch/lstm_tikz.tex`, and `pytorch/dilated_cnn_tikz.tex` to a consistent, professional style and layout that highlights the active temporal branch, the spatial MLP branch, the `time` fusion, and the head. 
- Each block now displays the input/output shapes (e.g. `(B, C_in, T)`, `(B, g, T)`, `(B, 128)` or `(B, O)`) so shape flow is explicit. 
- Removed Identity/inactive branches and extraneous legends to keep diagrams compact and manuscript-ready. 
- Prepared the `.tex` sources for PDF generation (TikZ sources are ready to compile with a TeX engine).

### Testing
- Attempted to compile PDFs with `pdflatex` for `pytorch/gru_tikz.tex`, `pytorch/lstm_tikz.tex`, and `pytorch/dilated_cnn_tikz.tex`, which failed because `pdflatex` is not installed in the environment. 
- Checked for alternative TeX engines with `which tectonic || which xelatex || which latexmk`, which returned no available engine, confirming the LaTeX toolchain is absent in the container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1fb0f9cb88331af0e6d9b52e488b3)