### PR TITLE
Reorient TikZ schemas vertically to reduce width

### DIFF
--- a/pytorch/dilated_cnn_tikz.tex
+++ b/pytorch/dilated_cnn_tikz.tex
@@ -13,28 +13,28 @@
 ]
 
 \node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$};
-\node[tblock, right=2.2cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$};
-\node[tblock, right=2.2cm of split] (cnn1) {Dilated Conv1d ($d=1$)\\$(B,\ g,\ T) \rightarrow (B,\ 128,\ T)$};
-\node[tblock, right=2.2cm of cnn1] (cnn2) {Dilated Conv1d ($d=3$)\\$(B,\ 128,\ T) \rightarrow (B,\ 128,\ T)$};
-\node[tblock, right=2.2cm of cnn2] (pool) {Temporal pooling (attn)\\$(B,\ 128,\ T) \rightarrow (B,\ 128)$};
+\node[tblock, below=1.8cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$};
+\node[tblock, below=1.8cm of split] (cnn1) {Dilated Conv1d ($d=1$)\\$(B,\ g,\ T) \rightarrow (B,\ 128,\ T)$};
+\node[tblock, below=1.8cm of cnn1] (cnn2) {Dilated Conv1d ($d=3$)\\$(B,\ 128,\ T) \rightarrow (B,\ 128,\ T)$};
+\node[tblock, below=1.8cm of cnn2] (pool) {Temporal pooling (attn)\\$(B,\ 128,\ T) \rightarrow (B,\ 128)$};
 
-\node[sblock, below=2.2cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$};
-\node[sblock, right=2.2cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
+\node[sblock, right=4.8cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$};
+\node[sblock, below=1.8cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
-\node[hblock, right=2.2cm of pool] (fusion) {Concatenation (time mode)\\$(B,\128)\oplus(B,\64) \rightarrow (B,\192)$};
-\node[hblock, right=2.2cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\192) \rightarrow (B,\128)$};
-\node[hblock, right=2.2cm of tfuse] (head1) {Head linear 1 + act\\$(B,\128) \rightarrow (B,\256)$};
-\node[hblock, right=2.2cm of head1] (head2) {Head linear 2 + act\\$(B,\256) \rightarrow (B,\64)$};
-\node[io, right=2.2cm of head2] (out) {Output layer\\$(B,\64) \rightarrow (B,\O)$};
+\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\128)\oplus(B,\64) \rightarrow (B,\192)$};
+\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\192) \rightarrow (B,\128)$};
+\node[hblock, below=1.8cm of tfuse] (head1) {Head linear 1 + act\\$(B,\128) \rightarrow (B,\256)$};
+\node[hblock, below=1.8cm of head1] (head2) {Head linear 2 + act\\$(B,\256) \rightarrow (B,\64)$};
+\node[io, below=1.8cm of head2] (out) {Output layer\\$(B,\64) \rightarrow (B,\O)$};
 
 \draw[arr] (xin) -- (split);
 \draw[arr] (split) -- (cnn1);
 \draw[arr] (cnn1) -- (cnn2);
 \draw[arr] (cnn2) -- (pool);
 \draw[arr] (pool) -- (fusion);
-\draw[arr] (xin) |- (ssplit);
+\draw[arr] (xin.east) -- ++(0.8,0) |- (ssplit.north);
 \draw[arr] (ssplit) -- (smlp);
-\draw[arr] (smlp) -| (fusion);
+\draw[arr] (smlp.west) -- ++(-0.8,0) |- (fusion.east);
 \draw[arr] (fusion) -- (tfuse);
 \draw[arr] (tfuse) -- (head1);
 \draw[arr] (head1) -- (head2);

--- a/pytorch/graphcast/diagrams/graphcastnet_tikz.tex
+++ b/pytorch/graphcast/diagrams/graphcastnet_tikz.tex
@@ -15,48 +15,48 @@
     \node[data, below=1.1cm of g2min, fill=blue!4] (meshedgein) {Mesh edges\\$E_{\text{mesh}} \in \mathbb{R}^{E_{\text{mesh}} \times 4}$};
 
     % Encoder embedder
-    \node[block, right=4.0cm of meshin, fill=orange!15] (embedder) {GraphCast encoder embedder\\(four MeshGraphMLPs)\\$C_{\text{in}},3,4 \rightarrow C_{\text{hidden}}$\\$C_{\text{hidden}} = \texttt{hidden\_dim} = C_{\text{in}}$\\LayerNorm + SiLU, $\texttt{hidden\_layers} = 1$};
+    \node[block, below=2.0cm of meshedgein, fill=orange!15] (embedder) {GraphCast encoder embedder\\(four MeshGraphMLPs)\\$C_{\text{in}},3,4 \rightarrow C_{\text{hidden}}$\\$C_{\text{hidden}} = \texttt{hidden\_dim} = C_{\text{in}}$\\LayerNorm + SiLU, $\texttt{hidden\_layers} = 1$};
 
-    \draw[arrow] (gridin.east) -- (embedder.west);
-    \draw[arrow] (meshin.east) -- (embedder.west);
-    \draw[arrow] (g2min.east) -- (embedder.west);
-    \draw[arrow] (meshedgein.east) -- (embedder.west);
+    \draw[arrow] (gridin.south) |- (embedder.west);
+    \draw[arrow] (meshin.south) |- (embedder.west);
+    \draw[arrow] (g2min.south) |- (embedder.west);
+    \draw[arrow] (meshedgein.south) -- (embedder.north);
 
     % Mesh graph encoder
-    \node[block, right=4.2cm of embedder, fill=orange!10] (encoder) {MeshGraphEncoder\\aggregator $= \texttt{sum}$\\produces encoded grid \\and mesh node states\\(LayerNorm, SiLU)};
+    \node[block, below=1.8cm of embedder, fill=orange!10] (encoder) {MeshGraphEncoder\\aggregator $= \texttt{sum}$\\produces encoded grid \\and mesh node states\\(LayerNorm, SiLU)};
 
-    \draw[arrow] (embedder) -- node[above]{embedded $X_{\text{grid}}, X_{\text{mesh}}$} (encoder);
+    \draw[arrow] (embedder) -- node[right]{embedded $X_{\text{grid}}, X_{\text{mesh}}$} (encoder);
 
     % Processor blocks
-    \node[block, above right=1.4cm and 3.8cm of encoder, fill=green!15] (procenc) {Processor encoder\\GraphCastMeshProcessor\\1 layer (feed-forward)\\};
-    \node[block, right=3.7cm of procenc, fill=green!12] (proccore) {Processor core\\GraphCastMeshProcessor\\$\texttt{processor\_layers} = 4$\\(MeshProcessorBlock repeated)\\LayerNorm, SiLU};
-    \node[block, right=1.4cm and 3.7cm of proccore, fill=green!9] (procdec) {Processor decoder\\GraphCastMeshProcessor\\1 layer};
+    \node[block, below=1.8cm of encoder, fill=green!15] (procenc) {Processor encoder\\GraphCastMeshProcessor\\1 layer (feed-forward)\\};
+    \node[block, below=1.8cm of procenc, fill=green!12] (proccore) {Processor core\\GraphCastMeshProcessor\\$\texttt{processor\_layers} = 4$\\(MeshProcessorBlock repeated)\\LayerNorm, SiLU};
+    \node[block, below=1.8cm of proccore, fill=green!9] (procdec) {Processor decoder\\GraphCastMeshProcessor\\1 layer};
 
-    \draw[arrow] (encoder.north east) |- node[pos=0.3, above]{mesh edges hidden} (procenc.west);
-    \draw[arrow] (procenc) -- node[above]{mesh latent features} (proccore);
-    \draw[arrow] (proccore) -- node[above]{refined mesh latent} (procdec);
+    \draw[arrow] (encoder) -- node[right]{mesh edges hidden} (procenc);
+    \draw[arrow] (procenc) -- node[right]{mesh latent features} (proccore);
+    \draw[arrow] (proccore) -- node[right]{refined mesh latent} (procdec);
     
     % Decoder embedder input
-    \node[data, below=3.3cm of meshedgein, fill=blue!12] (m2gin) {Mesh\,$\rightarrow$\,grid edges\\$E_{m2g} \in \mathbb{R}^{E_{m2g} \times 4}$};
-    \node[block, right=4.0cm of m2gin, fill=purple!12] (decembed) {GraphCast decoder embedder\\MeshGraphMLP\\$4 \rightarrow C_{\text{hidden}}$\\LayerNorm, SiLU};
-    \draw[arrow] (m2gin.east) -- (decembed.west);
+    \node[data, below=1.8cm of procdec, fill=blue!12] (m2gin) {Mesh\,$\rightarrow$\,grid edges\\$E_{m2g} \in \mathbb{R}^{E_{m2g} \times 4}$};
+    \node[block, below=1.8cm of m2gin, fill=purple!12] (decembed) {GraphCast decoder embedder\\MeshGraphMLP\\$4 \rightarrow C_{\text{hidden}}$\\LayerNorm, SiLU};
+    \draw[arrow] (m2gin) -- (decembed);
 
     % MeshGraphDecoder
-    \node[block, right=5.4cm of encoder, yshift=-2.2cm, fill=purple!9] (decoder) {MeshGraphDecoder\\aggregator $= \texttt{sum}$\\combines encoded grid,\\processed mesh nodes,\\and embedded $E_{m2g}$};
+    \node[block, below=1.8cm of decembed, fill=purple!9] (decoder) {MeshGraphDecoder\\aggregator $= \texttt{sum}$\\combines encoded grid,\\processed mesh nodes,\\and embedded $E_{m2g}$};
 
-    \draw[arrow] (encoder.south east) |- node[pos=0.25, right]{encoded grid nodes} (decoder.west);
-    \draw[arrow] (procdec.south east) |- node[pos=0.5, above]{processed mesh nodes} (decoder.north);
-    \draw[arrow] (decembed.east) -- (decoder.south);
+    \draw[arrow] (encoder.east) -- ++(2.0,0) |- node[pos=0.25, right]{encoded grid nodes} (decoder.west);
+    \draw[arrow] (procdec.east) -- ++(1.4,0) |- node[pos=0.5, right]{processed mesh nodes} (decoder.east);
+    \draw[arrow] (decembed) -- (decoder);
 
     % Finale MLP
-    \node[block, right=4.2cm of decoder, fill=red!12] (finale) {MeshGraphMLP finale\\$C_{\text{hidden}} \rightarrow C_{\text{out}}$\\$C_{\text{out}} = \texttt{output\_dim\_grid\_nodes} = 256$};
+    \node[block, below=1.8cm of decoder, fill=red!12] (finale) {MeshGraphMLP finale\\$C_{\text{hidden}} \rightarrow C_{\text{out}}$\\$C_{\text{out}} = \texttt{output\_dim\_grid\_nodes} = 256$};
     \draw[arrow] (decoder) -- (finale);
 
-    \node[data, right=3.8cm of finale, fill=red!18] (gridout) {Predicted grid fields\\$Y \in \mathbb{R}^{N_{\text{grid}} \times 256}$};
+    \node[data, below=1.8cm of finale, fill=red!18] (gridout) {Predicted grid fields\\$Y \in \mathbb{R}^{N_{\text{grid}} \times 256}$};
     \draw[arrow] (finale) -- (gridout);
 
     % Legend
-    \node[below=2.6cm of decoder, align=left] (legend) {
+    \node[below=2.0cm of gridout, align=left] (legend) {
         \begin{minipage}{15cm}
             \textbf{Default parameters from \texttt{make\_model('graphCast', \dots)}}
             \begin{itemize}

--- a/pytorch/gru_tikz.tex
+++ b/pytorch/gru_tikz.tex
@@ -14,28 +14,28 @@
 
 % Temporal branch
 \node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$};
-\node[tblock, right=2.2cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$\\$g=|\texttt{temporal\_idx}|$};
-\node[tblock, right=2.2cm of split] (gru) {2-layer GRU\\$(B,\ g,\ T) \rightarrow (B,\ T,\ G)$\\$G=\texttt{gru\_size}=128$};
+\node[tblock, below=1.8cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$\\$g=|\texttt{temporal\_idx}|$};
+\node[tblock, below=1.8cm of split] (gru) {2-layer GRU\\$(B,\ g,\ T) \rightarrow (B,\ T,\ G)$\\$G=\texttt{gru\_size}=128$};
 \node[tblock, right=2.2cm of gru] (pool) {Temporal pooling (flatten)\\$(B,\ T,\ G) \rightarrow (B,\ T\cdot G)$};
 
 % Spatial branch
-\node[sblock, below=2.2cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$\\$s=|\texttt{static\_idx}|$};
-\node[sblock, right=2.2cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
+\node[sblock, right=4.8cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$\\$s=|\texttt{static\_idx}|$};
+\node[sblock, below=1.8cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
 % Fusion + head
-\node[hblock, right=2.2cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ T\cdot G)\oplus(B,\64) \rightarrow (B,\ T\cdot G+64)$};
-\node[hblock, right=2.2cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ T\cdot G+64) \rightarrow (B,\ 128)$};
-\node[hblock, right=2.2cm of tfuse] (head1) {Head linear 1 + act\\$(B,\ 128) \rightarrow (B,\ 256)$};
-\node[hblock, right=2.2cm of head1] (head2) {Head linear 2 + act\\$(B,\ 256) \rightarrow (B,\ 64)$};
-\node[io, right=2.2cm of head2] (out) {Output layer\\$(B,\ 64) \rightarrow (B,\ O)$\\$O=\texttt{out\_channels}$};
+\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ T\cdot G)\oplus(B,\64) \rightarrow (B,\ T\cdot G+64)$};
+\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ T\cdot G+64) \rightarrow (B,\ 128)$};
+\node[hblock, below=1.8cm of tfuse] (head1) {Head linear 1 + act\\$(B,\ 128) \rightarrow (B,\ 256)$};
+\node[hblock, below=1.8cm of head1] (head2) {Head linear 2 + act\\$(B,\ 256) \rightarrow (B,\ 64)$};
+\node[io, below=1.8cm of head2] (out) {Output layer\\$(B,\ 64) \rightarrow (B,\ O)$\\$O=\texttt{out\_channels}$};
 
 \draw[arr] (xin) -- (split);
 \draw[arr] (split) -- (gru);
 \draw[arr] (gru) -- (pool);
 \draw[arr] (pool) -- (fusion);
-\draw[arr] (xin) |- (ssplit);
+\draw[arr] (xin.east) -- ++(0.8,0) |- (ssplit.north);
 \draw[arr] (ssplit) -- (smlp);
-\draw[arr] (smlp) -| (fusion);
+\draw[arr] (smlp.west) -- ++(-0.8,0) |- (fusion.east);
 \draw[arr] (fusion) -- (tfuse);
 \draw[arr] (tfuse) -- (head1);
 \draw[arr] (head1) -- (head2);

--- a/pytorch/lstm_tikz.tex
+++ b/pytorch/lstm_tikz.tex
@@ -13,26 +13,26 @@
 ]
 
 \node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$};
-\node[tblock, right=2.2cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$};
-\node[tblock, right=2.2cm of split] (lstm) {2-layer LSTM\\$(B,\ g,\ T) \rightarrow (B,\ T,\ L)$\\$L=\texttt{lstm\_size}=128$};
+\node[tblock, below=1.8cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$};
+\node[tblock, below=1.8cm of split] (lstm) {2-layer LSTM\\$(B,\ g,\ T) \rightarrow (B,\ T,\ L)$\\$L=\texttt{lstm\_size}=128$};
 \node[tblock, right=2.2cm of lstm] (pool) {Temporal pooling (attn)\\$(B,\ T,\ L) \rightarrow (B,\ L)$};
 
-\node[sblock, below=2.2cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$};
-\node[sblock, right=2.2cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
+\node[sblock, right=4.8cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$};
+\node[sblock, below=1.8cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
-\node[hblock, right=2.2cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ L)\oplus(B,\64) \rightarrow (B,\ L+64)$};
-\node[hblock, right=2.2cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ L+64) \rightarrow (B,\ 128)$};
-\node[hblock, right=2.2cm of tfuse] (head1) {Head linear 1 + act\\$(B,\ 128) \rightarrow (B,\ 256)$};
-\node[hblock, right=2.2cm of head1] (head2) {Head linear 2 + act\\$(B,\ 256) \rightarrow (B,\ 64)$};
-\node[io, right=2.2cm of head2] (out) {Output layer\\$(B,\ 64) \rightarrow (B,\ O)$};
+\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ L)\oplus(B,\64) \rightarrow (B,\ L+64)$};
+\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ L+64) \rightarrow (B,\ 128)$};
+\node[hblock, below=1.8cm of tfuse] (head1) {Head linear 1 + act\\$(B,\ 128) \rightarrow (B,\ 256)$};
+\node[hblock, below=1.8cm of head1] (head2) {Head linear 2 + act\\$(B,\ 256) \rightarrow (B,\ 64)$};
+\node[io, below=1.8cm of head2] (out) {Output layer\\$(B,\ 64) \rightarrow (B,\ O)$};
 
 \draw[arr] (xin) -- (split);
 \draw[arr] (split) -- (lstm);
 \draw[arr] (lstm) -- (pool);
 \draw[arr] (pool) -- (fusion);
-\draw[arr] (xin) |- (ssplit);
+\draw[arr] (xin.east) -- ++(0.8,0) |- (ssplit.north);
 \draw[arr] (ssplit) -- (smlp);
-\draw[arr] (smlp) -| (fusion);
+\draw[arr] (smlp.west) -- ++(-0.8,0) |- (fusion.east);
 \draw[arr] (fusion) -- (tfuse);
 \draw[arr] (tfuse) -- (head1);
 \draw[arr] (head1) -- (head2);

--- a/pytorch/netmlp_tikz.tex
+++ b/pytorch/netmlp_tikz.tex
@@ -12,13 +12,13 @@
         $T = \texttt{n\_sequences}$};
 
     % Sequence flattening
-    \node[block, right=2.9cm of input, fill=orange!15] (flatten) {Sequence flattening\\
+    \node[block, below=1.9cm of input, fill=orange!15] (flatten) {Sequence flattening\\
         reshape to $\mathbb{R}^{B \times (C_{in} \cdot T)}$};
 
     \draw[arrow] (input) -- (flatten);
 
     % Linear layers and activations
-    \node[block, right=2.9cm of flatten, fill=purple!12] (linear1) {Linear layer 1\\$\mathbb{R}^{C_{in} \cdot T} \rightarrow \mathbb{R}^{hd1}$\\
+    \node[block, below=1.9cm of flatten, fill=purple!12] (linear1) {Linear layer 1\\$\mathbb{R}^{C_{in} \cdot T} \rightarrow \mathbb{R}^{hd1}$\\
         activation ReLU};
 
     \draw[arrow] (flatten) -- (linear1);


### PR DESCRIPTION
### Motivation
- Reduce horizontal space used by model diagrams so they fit better in narrow layouts by changing their flow from left-to-right to top-to-bottom.
- Preserve the original semantic content of diagrams while improving readability on constrained page widths.

### Description
- Converted layout anchors from `right=... of` to `below=... of` for the main processing chains in `pytorch/netmlp_tikz.tex`, `pytorch/dilated_cnn_tikz.tex`, `pytorch/gru_tikz.tex`, and `pytorch/lstm_tikz.tex` to stack blocks vertically.
- Repositioned the static branch and fusion/head blocks (e.g. using `right=4.8cm of split` and `below=1.8cm of ...`) to keep cross-branch connections readable.
- Updated arrow routing to maintain clear connections after reflow, replacing constructs like `\draw[arr] (xin) |- (ssplit);` with explicit paths such as `\draw[arr] (xin.east) -- ++(0.8,0) |- (ssplit.north);` and similar for `smlp`→`fusion`.
- Reworked `pytorch/graphcast/diagrams/graphcastnet_tikz.tex` to stack encoder/embedder/processor/decoder/finale vertically and adjusted connector endpoints and legend placement accordingly.

### Testing
- Located target files with `rg` and previewed them before change using `sed`, which completed successfully.
- Applied automated edits with an inline `python` script that performed the position and arrow replacements, which executed without error.
- Verified diffs with `git diff -- <files>` and checked the working tree with `git status --short`, both returning expected results.
- Staged and committed the changes with `git add ... && git commit -m "Reorient TikZ schemas vertically to reduce width"`, producing a successful commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1fec8e84483319a04c863349d38bd)