### PR TITLE
Update TikZ diagrams to reflect `temporal_pool='flatten'`

### DIFF
--- a/pytorch/dilated_cnn_tikz.tex
+++ b/pytorch/dilated_cnn_tikz.tex
@@ -12,17 +12,17 @@
   arr/.style={-{Latex[length=2.8mm]}, thick}
 ]
 
-\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$};
+\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$\\$T=11$};
 \node[tblock, below=1.8cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$};
 \node[tblock, below=1.8cm of split] (cnn1) {Dilated Conv1d ($d=1$)\\$(B,\ g,\ T) \rightarrow (B,\ 128,\ T)$};
 \node[tblock, below=1.8cm of cnn1] (cnn2) {Dilated Conv1d ($d=3$)\\$(B,\ 128,\ T) \rightarrow (B,\ 128,\ T)$};
-\node[tblock, below=1.8cm of cnn2] (pool) {Temporal pooling (flatten)\\$(B,\ 128,\ T) \rightarrow (B,\ 128\cdot T)$};
+\node[tblock, below=1.8cm of cnn2] (pool) {Temporal pooling (flatten)\\$(B,\ 128,\ T) \rightarrow (B,\ 128\cdot 11)$};
 
 \node[sblock, right=4.8cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$};
 \node[sblock, below=1.8cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
-\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\128\cdot T)\oplus(B,\64) \rightarrow (B,\128\cdot T+64)$};
-\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\128\cdot T+64) \rightarrow (B,\128)$};
+\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\128\cdot 11)\oplus(B,\64) \rightarrow (B,\1472)$};
+\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\1472) \rightarrow (B,\128)$};
 \node[hblock, below=1.8cm of tfuse] (head1) {Head linear 1 + act\\$(B,\128) \rightarrow (B,\256)$};
 \node[hblock, below=1.8cm of head1] (head2) {Head linear 2 + act\\$(B,\256) \rightarrow (B,\64)$};
 \node[io, below=1.8cm of head2] (out) {Output layer\\$(B,\64) \rightarrow (B,\O)$};

--- a/pytorch/dilated_cnn_tikz.tex
+++ b/pytorch/dilated_cnn_tikz.tex
@@ -16,13 +16,13 @@
 \node[tblock, below=1.8cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$};
 \node[tblock, below=1.8cm of split] (cnn1) {Dilated Conv1d ($d=1$)\\$(B,\ g,\ T) \rightarrow (B,\ 128,\ T)$};
 \node[tblock, below=1.8cm of cnn1] (cnn2) {Dilated Conv1d ($d=3$)\\$(B,\ 128,\ T) \rightarrow (B,\ 128,\ T)$};
-\node[tblock, below=1.8cm of cnn2] (pool) {Temporal pooling (attn)\\$(B,\ 128,\ T) \rightarrow (B,\ 128)$};
+\node[tblock, below=1.8cm of cnn2] (pool) {Temporal pooling (flatten)\\$(B,\ 128,\ T) \rightarrow (B,\ 128\cdot T)$};
 
 \node[sblock, right=4.8cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$};
 \node[sblock, below=1.8cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
-\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\128)\oplus(B,\64) \rightarrow (B,\192)$};
-\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\192) \rightarrow (B,\128)$};
+\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\128\cdot T)\oplus(B,\64) \rightarrow (B,\128\cdot T+64)$};
+\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\128\cdot T+64) \rightarrow (B,\128)$};
 \node[hblock, below=1.8cm of tfuse] (head1) {Head linear 1 + act\\$(B,\128) \rightarrow (B,\256)$};
 \node[hblock, below=1.8cm of head1] (head2) {Head linear 2 + act\\$(B,\256) \rightarrow (B,\64)$};
 \node[io, below=1.8cm of head2] (out) {Output layer\\$(B,\64) \rightarrow (B,\O)$};

--- a/pytorch/gru_tikz.tex
+++ b/pytorch/gru_tikz.tex
@@ -13,18 +13,18 @@
 ]
 
 % Temporal branch
-\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$};
+\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$\\$T=11$};
 \node[tblock, below=1.8cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$\\$g=|\texttt{temporal\_idx}|$};
-\node[tblock, below=1.8cm of split] (gru) {2-layer GRU\\$(B,\ g,\ T) \rightarrow (B,\ T,\ G)$\\$G=\texttt{gru\_size}=128$};
-\node[tblock, right=2.2cm of gru] (pool) {Temporal pooling (flatten)\\$(B,\ T,\ G) \rightarrow (B,\ T\cdot G)$};
+\node[tblock, below=1.8cm of split] (gru) {2-layer GRU\\$(B,\ g,\ T) \rightarrow (B,\ T,\ 128)$\\$\texttt{gru\_size}=128$};
+\node[tblock, right=2.2cm of gru] (pool) {Temporal pooling (flatten)\\$(B,\ T,\ 128) \rightarrow (B,\ 1408)$};
 
 % Spatial branch
 \node[sblock, right=4.8cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$\\$s=|\texttt{static\_idx}|$};
 \node[sblock, below=1.8cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
 % Fusion + head
-\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ T\cdot G)\oplus(B,\64) \rightarrow (B,\ T\cdot G+64)$};
-\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ T\cdot G+64) \rightarrow (B,\ 128)$};
+\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ 1408)\oplus(B,\64) \rightarrow (B,\ 1472)$};
+\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ 1472) \rightarrow (B,\ 128)$};
 \node[hblock, below=1.8cm of tfuse] (head1) {Head linear 1 + act\\$(B,\ 128) \rightarrow (B,\ 256)$};
 \node[hblock, below=1.8cm of head1] (head2) {Head linear 2 + act\\$(B,\ 256) \rightarrow (B,\ 64)$};
 \node[io, below=1.8cm of head2] (out) {Output layer\\$(B,\ 64) \rightarrow (B,\ O)$\\$O=\texttt{out\_channels}$};

--- a/pytorch/lstm_tikz.tex
+++ b/pytorch/lstm_tikz.tex
@@ -14,14 +14,14 @@
 
 \node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$\\$T=11$};
 \node[tblock, below=1.8cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$};
-\node[tblock, below=1.8cm of split] (lstm) {2-layer LSTM\\$(B,\ g,\ T) \rightarrow (B,\ T,\ L)$\\$L=\texttt{lstm\_size}=128$};
-\node[tblock, right=2.2cm of lstm] (pool) {Temporal pooling (flatten)\\$(B,\ T,\ L) \rightarrow (B,\ 11\cdot L)$};
+\node[tblock, below=1.8cm of split] (lstm) {2-layer LSTM\\$(B,\ g,\ T) \rightarrow (B,\ T,\ 128)$\\$\texttt{lstm\_size}=128$};
+\node[tblock, right=2.2cm of lstm] (pool) {Temporal pooling (flatten)\\$(B,\ T,\ 128) \rightarrow (B,\ 1408)$};
 
 \node[sblock, right=4.8cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$};
 \node[sblock, below=1.8cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
-\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ 11\cdot L)\oplus(B,\64) \rightarrow (B,\ 11\cdot L+64)$};
-\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ 11\cdot L+64) \rightarrow (B,\ 128)$};
+\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ 1408)\oplus(B,\64) \rightarrow (B,\ 1472)$};
+\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ 1472) \rightarrow (B,\ 128)$};
 \node[hblock, below=1.8cm of tfuse] (head1) {Head linear 1 + act\\$(B,\ 128) \rightarrow (B,\ 256)$};
 \node[hblock, below=1.8cm of head1] (head2) {Head linear 2 + act\\$(B,\ 256) \rightarrow (B,\ 64)$};
 \node[io, below=1.8cm of head2] (out) {Output layer\\$(B,\ 64) \rightarrow (B,\ O)$};

--- a/pytorch/lstm_tikz.tex
+++ b/pytorch/lstm_tikz.tex
@@ -12,16 +12,16 @@
   arr/.style={-{Latex[length=2.8mm]}, thick}
 ]
 
-\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$};
+\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$\\$T=11$};
 \node[tblock, below=1.8cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$};
 \node[tblock, below=1.8cm of split] (lstm) {2-layer LSTM\\$(B,\ g,\ T) \rightarrow (B,\ T,\ L)$\\$L=\texttt{lstm\_size}=128$};
-\node[tblock, right=2.2cm of lstm] (pool) {Temporal pooling (flatten)\\$(B,\ T,\ L) \rightarrow (B,\ T\cdot L)$};
+\node[tblock, right=2.2cm of lstm] (pool) {Temporal pooling (flatten)\\$(B,\ T,\ L) \rightarrow (B,\ 11\cdot L)$};
 
 \node[sblock, right=4.8cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$};
 \node[sblock, below=1.8cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
-\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ T\cdot L)\oplus(B,\64) \rightarrow (B,\ T\cdot L+64)$};
-\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ T\cdot L+64) \rightarrow (B,\ 128)$};
+\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ 11\cdot L)\oplus(B,\64) \rightarrow (B,\ 11\cdot L+64)$};
+\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ 11\cdot L+64) \rightarrow (B,\ 128)$};
 \node[hblock, below=1.8cm of tfuse] (head1) {Head linear 1 + act\\$(B,\ 128) \rightarrow (B,\ 256)$};
 \node[hblock, below=1.8cm of head1] (head2) {Head linear 2 + act\\$(B,\ 256) \rightarrow (B,\ 64)$};
 \node[io, below=1.8cm of head2] (out) {Output layer\\$(B,\ 64) \rightarrow (B,\ O)$};

--- a/pytorch/lstm_tikz.tex
+++ b/pytorch/lstm_tikz.tex
@@ -15,13 +15,13 @@
 \node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$};
 \node[tblock, below=1.8cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$};
 \node[tblock, below=1.8cm of split] (lstm) {2-layer LSTM\\$(B,\ g,\ T) \rightarrow (B,\ T,\ L)$\\$L=\texttt{lstm\_size}=128$};
-\node[tblock, right=2.2cm of lstm] (pool) {Temporal pooling (attn)\\$(B,\ T,\ L) \rightarrow (B,\ L)$};
+\node[tblock, right=2.2cm of lstm] (pool) {Temporal pooling (flatten)\\$(B,\ T,\ L) \rightarrow (B,\ T\cdot L)$};
 
 \node[sblock, right=4.8cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$};
 \node[sblock, below=1.8cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
-\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ L)\oplus(B,\64) \rightarrow (B,\ L+64)$};
-\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ L+64) \rightarrow (B,\ 128)$};
+\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ T\cdot L)\oplus(B,\64) \rightarrow (B,\ T\cdot L+64)$};
+\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ T\cdot L+64) \rightarrow (B,\ 128)$};
 \node[hblock, below=1.8cm of tfuse] (head1) {Head linear 1 + act\\$(B,\ 128) \rightarrow (B,\ 256)$};
 \node[hblock, below=1.8cm of head1] (head2) {Head linear 2 + act\\$(B,\ 256) \rightarrow (B,\ 64)$};
 \node[io, below=1.8cm of head2] (out) {Output layer\\$(B,\ 64) \rightarrow (B,\ O)$};


### PR DESCRIPTION
### Motivation
- Reflect the new configuration `temporal_pool = 'flatten'` in the architecture diagrams and keep tensor-shape annotations consistent with the flatten temporal pooling behavior.

### Description
- Updated `pytorch/lstm_tikz.tex` to change the temporal pooling label from `attn` to `flatten` and to update the temporal branch output shape from `(B, L)` to `(B, T·L)` and the fusion/time-fusion shapes to `(B, T·L+64)` and `(B, T·L+64) -> (B, 128)` respectively.
- Updated `pytorch/dilated_cnn_tikz.tex` to change the temporal pooling label from `attn` to `flatten` and to update the temporal branch output shape from `(B, 128)` to `(B, 128·T)` and the fusion/time-fusion shapes to `(B, 128·T+64)` and `(B, 128·T+64) -> (B, 128)` respectively.
- Changes are purely textual updates to TikZ `.tex` diagram files and do not alter runtime code paths.

### Testing
- No automated tests were executed because the change is text-only (diagram updates).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20049b8bc83319b1dece943a62a21)