### PR TITLE
Update TikZ model diagrams to explicit T=11 and flattened temporal pooling sizes

### DIFF
--- a/pytorch/dilated_cnn_tikz.tex
+++ b/pytorch/dilated_cnn_tikz.tex
@@ -12,17 +12,17 @@
   arr/.style={-{Latex[length=2.8mm]}, thick}
 ]
 
-\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$};
+\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$\\$T=11$};
 \node[tblock, below=1.8cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$};
 \node[tblock, below=1.8cm of split] (cnn1) {Dilated Conv1d ($d=1$)\\$(B,\ g,\ T) \rightarrow (B,\ 128,\ T)$};
 \node[tblock, below=1.8cm of cnn1] (cnn2) {Dilated Conv1d ($d=3$)\\$(B,\ 128,\ T) \rightarrow (B,\ 128,\ T)$};
-\node[tblock, below=1.8cm of cnn2] (pool) {Temporal pooling (attn)\\$(B,\ 128,\ T) \rightarrow (B,\ 128)$};
+\node[tblock, below=1.8cm of cnn2] (pool) {Temporal pooling (flatten)\\$(B,\ 128,\ T) \rightarrow (B,\ 128\cdot 11)$};
 
 \node[sblock, right=4.8cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$};
 \node[sblock, below=1.8cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
-\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\128)\oplus(B,\64) \rightarrow (B,\192)$};
-\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\192) \rightarrow (B,\128)$};
+\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\128\cdot 11)\oplus(B,\64) \rightarrow (B,\1472)$};
+\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\1472) \rightarrow (B,\128)$};
 \node[hblock, below=1.8cm of tfuse] (head1) {Head linear 1 + act\\$(B,\128) \rightarrow (B,\256)$};
 \node[hblock, below=1.8cm of head1] (head2) {Head linear 2 + act\\$(B,\256) \rightarrow (B,\64)$};
 \node[io, below=1.8cm of head2] (out) {Output layer\\$(B,\64) \rightarrow (B,\O)$};

--- a/pytorch/gru_tikz.tex
+++ b/pytorch/gru_tikz.tex
@@ -13,18 +13,18 @@
 ]
 
 % Temporal branch
-\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$};
+\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$\\$T=11$};
 \node[tblock, below=1.8cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$\\$g=|\texttt{temporal\_idx}|$};
-\node[tblock, below=1.8cm of split] (gru) {2-layer GRU\\$(B,\ g,\ T) \rightarrow (B,\ T,\ G)$\\$G=\texttt{gru\_size}=128$};
-\node[tblock, right=2.2cm of gru] (pool) {Temporal pooling (flatten)\\$(B,\ T,\ G) \rightarrow (B,\ T\cdot G)$};
+\node[tblock, below=1.8cm of split] (gru) {2-layer GRU\\$(B,\ g,\ T) \rightarrow (B,\ T,\ 128)$\\$\texttt{gru\_size}=128$};
+\node[tblock, right=2.2cm of gru] (pool) {Temporal pooling (flatten)\\$(B,\ T,\ 128) \rightarrow (B,\ 1408)$};
 
 % Spatial branch
 \node[sblock, right=4.8cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$\\$s=|\texttt{static\_idx}|$};
 \node[sblock, below=1.8cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
 % Fusion + head
-\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ T\cdot G)\oplus(B,\64) \rightarrow (B,\ T\cdot G+64)$};
-\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ T\cdot G+64) \rightarrow (B,\ 128)$};
+\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ 1408)\oplus(B,\64) \rightarrow (B,\ 1472)$};
+\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ 1472) \rightarrow (B,\ 128)$};
 \node[hblock, below=1.8cm of tfuse] (head1) {Head linear 1 + act\\$(B,\ 128) \rightarrow (B,\ 256)$};
 \node[hblock, below=1.8cm of head1] (head2) {Head linear 2 + act\\$(B,\ 256) \rightarrow (B,\ 64)$};
 \node[io, below=1.8cm of head2] (out) {Output layer\\$(B,\ 64) \rightarrow (B,\ O)$\\$O=\texttt{out\_channels}$};

--- a/pytorch/lstm_tikz.tex
+++ b/pytorch/lstm_tikz.tex
@@ -12,16 +12,16 @@
   arr/.style={-{Latex[length=2.8mm]}, thick}
 ]
 
-\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$};
+\node[io] (xin) {Input $X$\\$(B,\ C_{in},\ T)$\\$T=11$};
 \node[tblock, below=1.8cm of xin] (split) {Temporal selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ g,\ T)$};
-\node[tblock, below=1.8cm of split] (lstm) {2-layer LSTM\\$(B,\ g,\ T) \rightarrow (B,\ T,\ L)$\\$L=\texttt{lstm\_size}=128$};
-\node[tblock, right=2.2cm of lstm] (pool) {Temporal pooling (attn)\\$(B,\ T,\ L) \rightarrow (B,\ L)$};
+\node[tblock, below=1.8cm of split] (lstm) {2-layer LSTM\\$(B,\ g,\ T) \rightarrow (B,\ T,\ 128)$\\$\texttt{lstm\_size}=128$};
+\node[tblock, right=2.2cm of lstm] (pool) {Temporal pooling (flatten)\\$(B,\ T,\ 128) \rightarrow (B,\ 1408)$};
 
 \node[sblock, right=4.8cm of split] (ssplit) {Static selection\\$(B,\ C_{in},\ T) \rightarrow (B,\ s)$};
 \node[sblock, below=1.8cm of ssplit] (smlp) {Spatial MLP (2 layers)\\$(B,\ s) \rightarrow (B,\ 64)$};
 
-\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ L)\oplus(B,\64) \rightarrow (B,\ L+64)$};
-\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ L+64) \rightarrow (B,\ 128)$};
+\node[hblock, below=1.8cm of pool] (fusion) {Concatenation (time mode)\\$(B,\ 1408)\oplus(B,\64) \rightarrow (B,\ 1472)$};
+\node[hblock, below=1.8cm of fusion] (tfuse) {Time-fusion MLP\\$(B,\ 1472) \rightarrow (B,\ 128)$};
 \node[hblock, below=1.8cm of tfuse] (head1) {Head linear 1 + act\\$(B,\ 128) \rightarrow (B,\ 256)$};
 \node[hblock, below=1.8cm of head1] (head2) {Head linear 2 + act\\$(B,\ 256) \rightarrow (B,\ 64)$};
 \node[io, below=1.8cm of head2] (out) {Output layer\\$(B,\ 64) \rightarrow (B,\ O)$};


### PR DESCRIPTION
### Motivation
- Clarify the temporal dimension by making `T=11` explicit in the input nodes of the model diagrams.
- Replace attention pooling in the diagrams with flattened temporal pooling to reflect the actual flattened feature vectors used downstream.
- Make intermediate tensor shapes explicit so the diagrams show exact dimensionality after flattening and fusion (no implicit variables).

### Description
- Added `T=11` annotation to the `Input` node in `dilated_cnn_tikz.tex`, `gru_tikz.tex`, and `lstm_tikz.tex` to fix the time length in the diagrams.
- Replaced `Temporal pooling (attn)` with `Temporal pooling (flatten)` and updated the pooling outputs to the flattened size `128 * 11 = 1408` where appropriate.
- Updated concatenation and time-fusion MLP shapes to use the flattened dimensions (e.g. `(B, 1408) ⊕ (B, 64) -> (B, 1472)` and `Time-fusion MLP (B, 1472) -> (B, 128)`).
- Made GRU/LSTM hidden size explicit as `128` in labels and adjusted all derived shape annotations accordingly.

### Testing
- Compiled each updated TikZ file with `pdflatex` to check for syntax errors and successful diagram generation, and the compilations succeeded.
- No code/unit tests were modified or required for these documentation/diagram changes.
- Verified visually that annotated tensor shapes in the generated PDFs match the updated labels in the `.tex` sources.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20049b8bc83319b1dece943a62a21)